### PR TITLE
Build epinio-ui for more ARCHES

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,62 @@
+name: Release Test
+
+on:
+  workflow_dispatch:
+
+env:
+  # change this to embed a different UI dashboard
+  UI_BUNDLE_URL: https://github.com/rancher/dashboard/releases/download/epinio-standalone-v0.9.0-0.0.1/rancher-dashboard-epinio-standalone-embed.tar.gz
+
+jobs:
+  release:
+    runs-on: self-hosted
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      # A tag is mandatory but it will not be pushed in the repo
+      # because we do not release
+      -
+        name: Create fake tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag -a v99.0.0 -m "Fake tag for QA" --force
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Login to avoid quota
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.JUADK_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.JUADK_DOCKERHUB_PASSWORD }}
+      -
+        name: Download dashboard
+        run: |
+          mkdir ui
+          wget "${{ env.UI_BUNDLE_URL }}"
+          tar xfz *.tar.gz -C ui
+      -
+        name: Get current tag
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: 1.8.2
+          args: release --skip-announce --skip-validate --skip-sign --config .goreleaser-test.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser-test.yml
+++ b/.goreleaser-test.yml
@@ -1,0 +1,178 @@
+---
+project_name: epinio-ui
+
+archives:
+  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      amd64: x86_64
+    format: binary
+    format_overrides:
+      - goos: windows
+        format: zip
+
+before:
+  hooks:
+    - sh -c "cd src/jetstream && go mod download"
+
+builds:
+  - id: epinio-ui
+    dir: src/jetstream
+    binary: epinio-ui
+    ldflags:
+      - -w -s
+      - -X "main.appVersion={{ .Tag }}"
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - s390x
+    goarm:
+      - "7"
+    targets:
+    - darwin_amd64
+    - darwin_arm64
+    - linux_amd64_v1
+    - linux_arm64
+    - linux_arm_7
+    - linux_s390x
+
+changelog:
+  skip: false
+
+env:
+  - CGO_ENABLED=0
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+dockers:
+  -
+    use: buildx
+    # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
+    id: epinio-ui
+
+    # GOOS of the built binaries/packages that should be used.
+    goos: linux
+
+    # GOARCH of the built binaries/packages that should be used.
+    goarch: amd64
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - epinio-ui
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "juadk/epinio-ui:{{ .Tag }}"
+    - "juadk/epinio-ui:latest"
+
+    # Skips the docker push.
+    #skip_push: "true"
+
+    # Path to the Dockerfile (from the project root).
+    dockerfile: Dockerfile
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
+    - "--label=org.opencontainers.image.source=https://github.com/juadk/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/amd64"
+
+    # If your Dockerfile copies files other than binaries and packages,
+    # you should list them here as well.
+    # Note that GoReleaser will create the same structure inside a temporary
+    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
+    # `COPY foo/bar.json /whatever.json`.
+    # Also note that the paths here are relative to the folder in which
+    # GoReleaser is being run (usually the repository root folder).
+    # This field does not support wildcards, you can add an entire folder here
+    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
+    extra_files:
+    - ui/
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - epinio-ui
+    image_templates:
+    - "juadk/epinio-ui:{{ .Tag }}-arm64v8"
+    - "juadk/epinio-ui:latest-arm64v8"
+    dockerfile: Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/juadk/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/arm64/v8"
+  -
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    ids:
+    - epinio-ui
+    image_templates:
+    - "juadk/epinio-ui:{{ .Tag }}-armv7"
+    - "juadk/epinio-ui:latest-armv7"
+    dockerfile: Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/juadk/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/arm/v7"
+  -
+    use: buildx
+    goos: linux
+    goarch: s390x
+    ids:
+    - epinio-ui
+    image_templates:
+    - "juadk/epinio-ui:{{ .Tag }}-s390x"
+    - "juadk/epinio-ui:latest-s390x"
+    dockerfile: Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/juadk/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/s390x"
+
+release:
+  disable: true
+
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  -
+    name_template: "juadk/epinio-ui:{{ .Tag }}"
+    image_templates:
+    - "juadk/epinio-ui:{{ .Tag }}-amd64"
+    - "juadk/epinio-ui:{{ .Tag }}-arm64v8"
+    - "juadk/epinio-ui:{{ .Tag }}-armv7"
+    - "juadk/epinio-ui:{{ .Tag }}-s390x"
+  -
+    name_template: "juadk/epinio-ui:latest"
+    image_templates:
+    - "juadk/epinio-ui:{{ .Tag }}-amd64"
+    - "juadk/epinio-ui:{{ .Tag }}-arm64v8"
+    - "juadk/epinio-ui:{{ .Tag }}-armv7"
+    - "juadk/epinio-ui:{{ .Tag }}-s390x"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Build epinio-ui for more ARCHES.
I'm not very experimented with building so to do not break the current release process, this PR uses different files like `release-test.yml `and `.goreleaser-test.yml`.
Once validated, it will be merged in only one file.

## Description
<!--- Describe your changes in detail -->
Epinio is already built for most of all the ARCHES, but epinio has epinio-ui as a dependency, so it has to be built in the same ARCHES.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm trying to fix https://github.com/epinio/epinio/issues/1473

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I'm not very experimented with building so to do not break the current release process, this PR uses different files like `release-test.yml `and `.goreleaser-test.yml`.
Once validated, it will be merged in only one file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
