### PR TITLE
Remove QueryEscape on Epinio Basic Authentication

### DIFF
--- a/src/jetstream/authepinio.go
+++ b/src/jetstream/authepinio.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"math"
 	"net/http"
-	"net/url"
 
 	log "github.com/sirupsen/logrus"
 
@@ -185,7 +184,7 @@ func (a *epinioAuth) verifyEpinioCreds(username, password string) error {
 		return fmt.Errorf(msg, err)
 	}
 
-	req.SetBasicAuth(url.QueryEscape(username), url.QueryEscape(password))
+	req.SetBasicAuth(username, password)
 
 	var h = a.p.GetHttpClientForRequest(req, epinioEndpoint.SkipSSLValidation)
 	res, err := h.Do(req)


### PR DESCRIPTION
## Description
This PR removes the `url.QueryEscape` for the Epinio Basic Authentication.

## Motivation and Context
Fixes: https://github.com/epinio/epinio/issues/1608

The Epinio backend is not expecting url encoded username or password, and so when we have special characters then it will fail.

I.e.: if we have a `Hell@World` password then it will reach Epinio as `Hell%40World`, and the auth will fail.

We cannot decode the password on the Epinio side because the Javascript requests made from the dashboard are not encoding the Basic Auth, so it's just simpler to remove the encoding.
