### PR TITLE
Build latest dashboard with `release next` action

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   SETUP_GO_VERSION: '1.18'
+  SETUP_NODE_VERSION: '16'
 
 jobs:
   release:
@@ -34,7 +35,7 @@ jobs:
         name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ env.SETUP_NODE_VERSION }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,4 +1,4 @@
-name: Release Next"
+name: Release Next
 
 on:
   workflow_dispatch:
@@ -13,8 +13,7 @@ permissions:
   packages: write
 
 env:
-  # change this to embed a different UI dashboard
-  UI_BUNDLE_URL: https://github.com/rancher/dashboard/releases/download/epinio-standalone-v1.2.0.0.0.1/rancher-dashboard-epinio-standalone-embed.tar.gz
+  SETUP_GO_VERSION: '1.18'
 
 jobs:
   release:
@@ -30,7 +29,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -41,15 +45,48 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # if the ui_bundle_url is defined download and unpack the dashboard
       -
         name: Download dashboard
+        if: ${{ github.events.inputs.ui_bundle_url != '' }}
         run: |
           mkdir ui
-          wget "${{ env.UI_BUNDLE_URL }}"
+          wget "${{ github.events.inputs.ui_bundle_url }}"
           tar xfz *.tar.gz -C ui
+
+      # otherwise fetch and build the latest dashboard from the repository
+      -
+        name: Checkout Rancher Dashboard UI
+        if: ${{ github.events.inputs.ui_bundle_url == '' }}
+        uses: actions/checkout@v2
+        with:
+          repository: rancher/dashboard
+          ref: epinio-dev
+          submodules: recursive
+          fetch-depth: 0
+      -
+        name: Build Epinio dashboard
+        if: ${{ github.events.inputs.ui_bundle_url == '' }}
+        run: |
+          pushd dashboard
+          ./.github/workflows/scripts/build-dashboard.sh
+          mv $OUTPUT_DIR/$ARTIFACT_NAME ../ui
+          popd
+          rm -rf dashboard
+        env:
+          RANCHER_ENV: epinio
+          EXCLUDES_PKG: rancher-components,harvester
+          EXCLUDES_NUXT_PLUGINS: plugins/plugin,plugins/version
+          OUTPUT_DIR: dist
+          RELEASE_DIR: release
+          ARTIFACT_NAME: rancher-dashboard-epinio-standalone-embed
+
+      #################
+
       -
         name: Run GoReleaser Cross
         run: ./build/bk-release.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UI_BUNDLE_URL: "${{ github.events.inputs.ui_bundle_url || env.UI_BUNDLE_URL }}"
+          UI_BUNDLE_URL: "${{ github.events.inputs.ui_bundle_url || 'dev' }}"

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -66,6 +66,7 @@ jobs:
           ref: epinio-dev
           submodules: recursive
           fetch-depth: 0
+          path: dashboard
       -
         name: Build Epinio dashboard
         if: ${{ github.events.inputs.ui_bundle_url == '' }}

--- a/.goreleaser-next.yml
+++ b/.goreleaser-next.yml
@@ -16,7 +16,7 @@ before:
 
 # binary builds
 builds:
-  
+
   # amd64
   - id: epinio-ui-amd64
     dir: src/jetstream

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
+# the user is set to avoid permission issue during the creation of the 'dist' folder
 docker run \
+    --user $(id -u):$(getent group docker | cut -d: -f3) \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd):/go/src/ui-backend \
     -w /go/src/ui-backend \

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -8,6 +8,7 @@ docker run \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd):/go/src/ui-backend \
     -w /go/src/ui-backend \
+    -e HOME=/go \
     -e CGO_ENABLED=1 \
     -e UI_BUNDLE_URL=$UI_BUNDLE_URL \
     goreleaser/goreleaser-cross:v1.19.3 -f .goreleaser-next.yml \

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-# the user is set to avoid permission issue during the creation of the 'dist' folder
+# the user is set to avoid permission issue during the creation of the 'dist' folder.
+# It has to be also into the docker group or it won't be able to use /var/run/docker.sock.
 docker run \
     --user $(id -u):$(getent group docker | cut -d: -f3) \
     -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
This PR updates the release-next action to checkout the Rancher Dashboard repo to the `epinio-dev` branch, to build then the latest available version.

A `ui_bundle_url` can be specified, and if any it will download and unzip this release.

No image will be published (yet).