### PR TITLE
Added multi-arch support to releases

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -91,7 +91,7 @@ jobs:
 
       -
         name: Run GoReleaser Cross
-        run: ./build/bk-release.sh
+        run: ./build/bk-release.sh release --rm-dist -f .goreleaser-next.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UI_BUNDLE_URL: "${{ github.event.inputs.ui_bundle_url || 'dev' }}"

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,6 +1,8 @@
 name: Release Next
 
 on:
+  schedule:
+    - cron:  '0 1 * * *'
   workflow_dispatch:
     inputs:
       ui_bundle_url:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
   packages: write
 
 env:
+  SETUP_GO_VERSION: '1.18'
   # change this to embed a different UI dashboard
   UI_BUNDLE_URL: https://github.com/rancher/dashboard/releases/download/epinio-standalone-v1.2.0.0.0.1/rancher-dashboard-epinio-standalone-embed.tar.gz
 
@@ -27,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: ${{ env.SETUP_GO_VERSION }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -49,14 +50,11 @@ jobs:
         id: get_tag
         run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+        name: Run GoReleaser Cross
+        run: ./build/bk-release.sh release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UI_BUNDLE_URL: "${{ env.UI_BUNDLE_URL }}"
 
       # Allow to release Epinio UI Helm chart automatically when we release Epinio.
       # The tag is sent to the Helm chart repo.

--- a/.goreleaser-next.yml
+++ b/.goreleaser-next.yml
@@ -14,6 +14,9 @@ before:
   hooks:
     - sh -c "cd src/jetstream && go mod download"
 
+release:
+  disable: true
+
 # binary builds
 builds:
 
@@ -108,3 +111,11 @@ dockers:
 
     extra_files:
     - ui/
+
+docker_manifests:
+  - id: epinio-ui
+    name_template: "ghcr.io/epinio/epinio-ui:latest-next-arm64v8"
+
+    image_templates:
+    - ghcr.io/epinio/epinio-ui:{{ .Version }}-amd64
+    - ghcr.io/epinio/epinio-ui:{{ .Version }}-arm64v8

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,21 +14,37 @@ before:
   hooks:
     - sh -c "cd src/jetstream && go mod download"
 
+# binary builds
 builds:
-  - id: epinio-ui
+
+  # amd64
+  - id: epinio-ui-amd64
     dir: src/jetstream
     binary: epinio-ui
     ldflags:
-      - -w -s
-      - -X "main.appVersion={{ .Tag }}"
+      - -w -s -X "main.appVersion={{ .Tag }}"
     goos:
       - linux
-      # - darwin
-      # - windows
     goarch:
       - amd64
-      # - arm64
-      # - arm
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+
+  # arm64
+  - id: epinio-ui-arm64
+    dir: src/jetstream
+    binary: epinio-ui
+    ldflags:
+      - -w -s -X "main.appVersion={{ .Version }}"
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+  
 
 changelog:
   skip: false
@@ -36,33 +52,26 @@ changelog:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
+# docker build
 dockers:
-  -
-    # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
-    id: epinio-ui
 
-    # GOOS of the built binaries/packages that should be used.
+  # amd64
+  - id: epinio-ui-amd64
     goos: linux
-
-    # GOARCH of the built binaries/packages that should be used.
     goarch: amd64
+    use: buildx
 
     # IDs to filter the binaries/packages.
     ids:
-    - epinio-ui
+    - epinio-ui-amd64
 
     # Templates of the Docker image names.
     image_templates:
-    - "ghcr.io/epinio/epinio-ui:{{ .Tag }}"
-    - "ghcr.io/epinio/epinio-ui:latest"
+    - "ghcr.io/epinio/epinio-ui:{{ .Tag }}-amd64"
+    - "ghcr.io/epinio/epinio-ui:latest-amd64"
 
     # Skips the docker push.
     #skip_push: "true"
-
-    # Path to the Dockerfile (from the project root).
-    dockerfile: Dockerfile
-
-    use: docker
 
     # Template of the docker build flags.
     build_flag_templates:
@@ -87,3 +96,53 @@ dockers:
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files:
     - ui/
+
+  # arm64
+  - id: epinio-ui-arm64
+    goos: linux
+    goarch: arm64
+    use: buildx
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - epinio-ui-arm64
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "ghcr.io/epinio/epinio-ui:{{ .Tag }}-arm64v8"
+    - "ghcr.io/epinio/epinio-ui:latest-arm64v8"
+
+    # Skips the docker push.
+    #skip_push: "true"
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/arm64/v8"
+
+    # If your Dockerfile copies files other than binaries and packages,
+    # you should list them here as well.
+    # Note that GoReleaser will create the same structure inside a temporary
+    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
+    # `COPY foo/bar.json /whatever.json`.
+    # Also note that the paths here are relative to the folder in which
+    # GoReleaser is being run (usually the repository root folder).
+    # This field does not support wildcards, you can add an entire folder here
+    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
+    extra_files:
+    - ui/
+
+docker_manifests:
+  - id: epinio-ui
+    name_template: "ghcr.io/epinio/epinio-ui:latest-next-arm64v8"
+
+    image_templates:
+    - ghcr.io/epinio/epinio-ui:{{ .Tag }}-amd64
+    - ghcr.io/epinio/epinio-ui:{{ .Tag }}-arm64v8

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -12,5 +12,4 @@ docker run \
     -e HOME=/go \
     -e CGO_ENABLED=1 \
     -e UI_BUNDLE_URL=$UI_BUNDLE_URL \
-    goreleaser/goreleaser-cross:v1.19.3 -f .goreleaser-next.yml \
-        --snapshot --rm-dist
+    goreleaser/goreleaser-cross:v1.19.3 $@


### PR DESCRIPTION
This PR adds the support for arm64 (ref: https://github.com/epinio/epinio/issues/1473).

We are able to deploy the Epinio UI for arm64 but there are still some issues for a full compatibility: https://github.com/epinio/epinio/issues/1850

---

This PR removes the `--snapshot` flag from the release script, so now the actions will perform a full release pushing the images. The `release-next` is using a different config file, with the `release: disabled` option, so when doing a `relese-next` no Github release will be created. To trigger a release-next it's possible to trigger it manually, and also a daily release will be scheduled.
