### PR TITLE
Fix release-next workflow

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -51,6 +51,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Get latest tag
+        id: get_latest_tag
+        run: echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+      -
+        name: Tag current commit as latest-next
+        run: git tag ${{ steps.get_latest_tag.outputs.LATEST_TAG }}-next
 
       # if the ui_bundle_url is defined download and unpack the dashboard
       -
@@ -96,4 +103,7 @@ jobs:
         run: ./build/bk-release.sh release --rm-dist -f .goreleaser-next.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UI_BUNDLE_URL: "${{ github.event.inputs.ui_bundle_url || 'dev' }}"
+          UI_BUNDLE_URL: "${{ github.event.inputs.ui_bundle_url || 'dev' }}"      
+      -
+        name: Cleanup the latest-next tag
+        run: git tag -d ${{ steps.get_latest_tag.outputs.LATEST_TAG }}-next

--- a/.goreleaser-next.yml
+++ b/.goreleaser-next.yml
@@ -17,6 +17,8 @@ before:
 release:
   disable: true
 
+dist: /tmp/_dist
+
 # binary builds
 builds:
 
@@ -114,7 +116,7 @@ dockers:
 
 docker_manifests:
   - id: epinio-ui
-    name_template: "ghcr.io/epinio/epinio-ui:latest-next-arm64v8"
+    name_template: "ghcr.io/epinio/epinio-ui:latest-next"
 
     image_templates:
     - ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-amd64

--- a/.goreleaser-next.yml
+++ b/.goreleaser-next.yml
@@ -25,7 +25,7 @@ builds:
     dir: src/jetstream
     binary: epinio-ui
     ldflags:
-      - -w -s -X "main.appVersion={{ .Version }}"
+      - -w -s -X "main.appVersion={{ incminor .Version }}-next"
     goos:
       - linux
     goarch:
@@ -39,7 +39,7 @@ builds:
     dir: src/jetstream
     binary: epinio-ui
     ldflags:
-      - -w -s -X "main.appVersion={{ .Version }}"
+      - -w -s -X "main.appVersion={{ incminor .Version }}-next"
     goos:
       - linux
     goarch:
@@ -68,7 +68,7 @@ dockers:
     - epinio-ui-amd64
 
     image_templates:
-    - "ghcr.io/epinio/epinio-ui:{{ .Version }}-amd64"
+    - "ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-amd64"
     - "ghcr.io/epinio/epinio-ui:latest-next-amd64"
 
     build_flag_templates:
@@ -76,7 +76,7 @@ dockers:
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.version={{ incminor .Version }}-next"
     - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
     - "--label=org.opencontainers.image.source=https://github.com/epinio/ui-backend"
     - "--build-arg=DIST_BINARY=epinio-ui"
@@ -95,7 +95,7 @@ dockers:
     - epinio-ui-arm64
 
     image_templates:
-    - "ghcr.io/epinio/epinio-ui:{{ .Version }}-arm64v8"
+    - "ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-arm64v8"
     - "ghcr.io/epinio/epinio-ui:latest-next-arm64v8"
 
     build_flag_templates:
@@ -103,7 +103,7 @@ dockers:
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.version={{ incminor .Version }}-next"
     - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
     - "--label=org.opencontainers.image.source=https://github.com/epinio/ui-backend"
     - "--build-arg=DIST_BINARY=epinio-ui"
@@ -117,5 +117,5 @@ docker_manifests:
     name_template: "ghcr.io/epinio/epinio-ui:latest-next-arm64v8"
 
     image_templates:
-    - ghcr.io/epinio/epinio-ui:{{ .Version }}-amd64
-    - ghcr.io/epinio/epinio-ui:{{ .Version }}-arm64v8
+    - ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-amd64
+    - ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-arm64v8

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ before:
   hooks:
     - sh -c "cd src/jetstream && go mod download"
 
+dist: /tmp/_dist
+
 # binary builds
 builds:
 

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -5,12 +5,10 @@ set -euo pipefail
 # the user is set to avoid permission issue during the creation of the 'dist' folder.
 # It has to be also into the docker group or it won't be able to use /var/run/docker.sock.
 docker run \
-    --user $(id -u):$(getent group docker | cut -d: -f3) \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $HOME/.docker/config.json:$HOME/.docker/config.json \
+    -v $HOME/.docker/config.json:/root/.docker/config.json \
     -v $(pwd):/go/src/ui-backend \
     -w /go/src/ui-backend \
-    -e HOME=/go \
     -e CGO_ENABLED=1 \
     -e UI_BUNDLE_URL=$UI_BUNDLE_URL \
     goreleaser/goreleaser-cross:v1.19.3 $@

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 docker run \
     --user $(id -u):$(getent group docker | cut -d: -f3) \
     -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $HOME/.docker/config.json:$HOME/.docker/config.json \
     -v $(pwd):/go/src/ui-backend \
     -w /go/src/ui-backend \
     -e HOME=/go \


### PR DESCRIPTION
This PR tries to fix the release-next workflow.

Goreleaser works only with tags ([nightly builds](https://goreleaser.com/customization/nightlies/) are a pro-feature), so the action is failing while trying to release from an untagged commit.

To fix this now the action will create a temporary tag with the `-next` suffix, and this will be used by Goreleaser, with an incremented value, and the `-next` suffix as well (so we are not conflicting with the actual releases).

We don't need anymore the custom user because the `dist` directory will be created inside the `/tmp` dir of the container, and will not clutter the runner filesystem.

### sample
Latest tag is: `v1.2.0`
A tag with `v1.2.0-next` will be created on the latest commit
This tag will be fetched by Goreleaser and incremented for the builds (`v1.3.0-next`).
At the end it will be deleted (maybe this is even not needed because the tag is not pushed).

