### PR TITLE
Automatic cleanup of old images

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -3,7 +3,7 @@ name: Delete old container images
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 1 * *"  # every day at 6 in the morning
+    - cron: "0 6 * * *"  # every day at 6 in the morning
 
 jobs:
   clean-ghcr:

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -20,4 +20,4 @@ jobs:
           keep-at-least: 1
           filter-tags: v*-g*
           filter-include-untagged: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.IMG_CLEANUP_TOKEN }}

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -18,6 +18,6 @@ jobs:
           account-type: org
           org-name: epinio
           keep-at-least: 1
-          filter-tags: v*-g*
+          filter-tags: v*-[0-9]*-g*
           filter-include-untagged: true
           token: ${{ secrets.IMG_CLEANUP_TOKEN }}

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,23 @@
+name: Delete old container images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 1 * *"  # every day at 6 in the morning
+
+jobs:
+  clean-ghcr:
+    name: Delete old unused container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged and dev containers older than a week
+        uses: snok/container-retention-policy@v1.5.1
+        with:
+          image-names: epinio-ui
+          cut-off: A week ago UTC
+          account-type: org
+          org-name: epinio
+          keep-at-least: 1
+          filter-tags: v*-g*
+          filter-include-untagged: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
cleanup flow - pattern `v*-g*` for the dev images (they have a `g`-prefix commit id in the tag). include the untagged as well

## Description

Added a github workflow to remove old images

## Motivation and Context

Fix https://github.com/epinio/epinio/issues/1953

## How Has This Been Tested?

CI enhancement. Not yet tested.

## Types of changes

- [x] Devops chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message