### PR TITLE
use a separate step to remove old untagged images

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -10,7 +10,7 @@ jobs:
     name: Delete old unused container images
     runs-on: ubuntu-latest
     steps:
-      - name: Delete untagged and dev containers older than a week
+      - name: Delete dev containers older than a week
         uses: snok/container-retention-policy@v1.5.1
         with:
           image-names: epinio-ui
@@ -21,3 +21,13 @@ jobs:
           filter-tags: v*-[0-9]*-g*
           filter-include-untagged: true
           token: ${{ secrets.IMG_CLEANUP_TOKEN }}
+      - name: Delete untagged containers older than a week
+        uses: snok/container-retention-policy@v1.5.1
+        with:
+          image-names: epinio-ui
+          cut-off: A week ago UTC
+          account-type: org
+          org-name: epinio
+          keep-at-least: 1
+          token: ${{ secrets.IMG_CLEANUP_TOKEN }}
+          untagged-only: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extended the cleanup workflow with a step specifically addressing old untagged images.
See also https://github.com/epinio/epinio/pull/1994 for the equivalent change for epinio.

## Motivation and Context

See https://github.com/epinio/epinio/issues/1955 and https://github.com/epinio/epinio/pull/1994

## How Has This Been Tested?

Run manual from PR.

## Types of changes

- [x] Devops
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message