### PR TITLE
Added s390x support

### DIFF
--- a/.goreleaser-next.yml
+++ b/.goreleaser-next.yml
@@ -49,7 +49,20 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-  
+
+  # s390x
+  - id: epinio-ui-s390x
+    dir: src/jetstream
+    binary: epinio-ui
+    ldflags:
+      - -w -s -X "main.appVersion={{ incminor .Version }}-next"
+    goos:
+      - linux
+    goarch:
+      - s390x
+    env:
+      - CC=s390x-linux-gnu-gcc
+      - CXX=s390x-linux-gnu-g++
 
 changelog:
   skip: false
@@ -114,6 +127,33 @@ dockers:
     extra_files:
     - ui/
 
+  # s390x
+  - id: epinio-ui-s390x
+    goos: linux
+    goarch: s390x
+    use: buildx
+
+    ids:
+    - epinio-ui-s390x
+
+    image_templates:
+    - "ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-s390x"
+    - "ghcr.io/epinio/epinio-ui:latest-next-s390x"
+
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{ incminor .Version }}-next"
+    - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/s390x"
+
+    extra_files:
+    - ui/
+
 docker_manifests:
   - id: epinio-ui
     name_template: "ghcr.io/epinio/epinio-ui:latest-next"
@@ -121,3 +161,4 @@ docker_manifests:
     image_templates:
     - ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-amd64
     - ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-arm64v8
+    - ghcr.io/epinio/epinio-ui:{{ incminor .Version }}-next-s390x

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ builds:
     dir: src/jetstream
     binary: epinio-ui
     ldflags:
-      - -w -s -X "main.appVersion={{ .Version }}"
+      - -w -s -X "main.appVersion={{ .Tag }}"
     goos:
       - linux
     goarch:
@@ -46,7 +46,20 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-  
+
+  # s390x
+  - id: epinio-ui-s390x
+    dir: src/jetstream
+    binary: epinio-ui
+    ldflags:
+      - -w -s -X "main.appVersion={{ .Tag }}"
+    goos:
+      - linux
+    goarch:
+      - s390x
+    env:
+      - CC=s390x-linux-gnu-gcc
+      - CXX=s390x-linux-gnu-g++
 
 changelog:
   skip: false
@@ -141,14 +154,58 @@ dockers:
     extra_files:
     - ui/
 
+  # s390x
+  - id: epinio-ui-s390x
+    goos: linux
+    goarch: s390x
+    use: buildx
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - epinio-ui-s390x
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "ghcr.io/epinio/epinio-ui:{{ .Tag }}-s390x"
+    - "ghcr.io/epinio/epinio-ui:latest-s390x"
+
+    # Skips the docker push.
+    #skip_push: "true"
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/s390x"
+
+    # If your Dockerfile copies files other than binaries and packages,
+    # you should list them here as well.
+    # Note that GoReleaser will create the same structure inside a temporary
+    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
+    # `COPY foo/bar.json /whatever.json`.
+    # Also note that the paths here are relative to the folder in which
+    # GoReleaser is being run (usually the repository root folder).
+    # This field does not support wildcards, you can add an entire folder here
+    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
+    extra_files:
+    - ui/
+
 docker_manifests:
   -
     name_template: "ghcr.io/epinio/epinio-ui:latest"
     image_templates:
     - ghcr.io/epinio/epinio-ui:{{ .Tag }}-amd64
     - ghcr.io/epinio/epinio-ui:{{ .Tag }}-arm64v8
+    - ghcr.io/epinio/epinio-ui:{{ .Tag }}-s390x
   -
     name_template: "ghcr.io/epinio/epinio-ui:{{ .Tag }}"
     image_templates:
     - ghcr.io/epinio/epinio-ui:{{ .Tag }}-amd64
     - ghcr.io/epinio/epinio-ui:{{ .Tag }}-arm64v8
+    - ghcr.io/epinio/epinio-ui:{{ .Tag }}-s390x

--- a/build/bk-release.sh
+++ b/build/bk-release.sh
@@ -12,4 +12,4 @@ docker run \
     -e CGO_ENABLED=1 \
     -e UI_BUNDLE_URL=$UI_BUNDLE_URL \
     -e GITHUB_TOKEN=$GITHUB_TOKEN \
-    goreleaser/goreleaser-cross:v1.19.3 $@
+    goreleaser/goreleaser-cross:v1.20.0 $@


### PR DESCRIPTION
FIx https://github.com/epinio/epinio/issues/1473

This PR adds the support for the `s390x` architecture, updating Goreleaser-cross to the latest version: https://github.com/goreleaser/goreleaser-cross/issues/15