### PR TITLE
Added internal authURL for Dex

### DIFF
--- a/src/jetstream/authepinio.go
+++ b/src/jetstream/authepinio.go
@@ -20,7 +20,7 @@ import (
 	"github.com/epinio/ui-backend/src/jetstream/repository/interfaces"
 )
 
-//More fields will be moved into here as global portalProxy struct is phased out
+// More fields will be moved into here as global portalProxy struct is phased out
 type epinioAuth struct {
 	databaseConnectionPool *sql.DB
 	p                      *portalProxy
@@ -30,7 +30,7 @@ func (a *epinioAuth) ShowConfig(config *interfaces.ConsoleConfig) {
 	log.Infof("... Epinio Auth             : %v", true)
 }
 
-//Login provides Local-auth specific Stratos login
+// Login provides Local-auth specific Stratos login
 func (a *epinioAuth) Login(c echo.Context) error {
 
 	//This check will remain in until auth is factored down into its own package
@@ -80,20 +80,20 @@ func (a *epinioAuth) Login(c echo.Context) error {
 	return err
 }
 
-//Logout provides Local-auth specific Stratos login
+// Logout provides Local-auth specific Stratos login
 func (a *epinioAuth) Logout(c echo.Context) error {
 	log.Debug("Logout")
 	return a.logout(c)
 }
 
-//GetUsername gets the user name for the specified local user
+// GetUsername gets the user name for the specified local user
 func (a *epinioAuth) GetUsername(userid string) (string, error) {
 	log.Debug("GetUsername")
 
 	return userid, nil // username == user guid
 }
 
-//GetUser gets the user guid for the specified local user
+// GetUser gets the user guid for the specified local user
 func (a *epinioAuth) GetUser(userGUID string) (*interfaces.ConnectedUser, error) {
 	log.Debug("GetUser")
 
@@ -117,7 +117,7 @@ func (a *epinioAuth) VerifySession(c echo.Context, sessionUser string, sessionEx
 	return nil
 }
 
-//epinioLocalLogin verifies local user credentials
+// epinioLocalLogin verifies local user credentials
 func (a *epinioAuth) epinioLocalLogin(c echo.Context) (string, string, error) {
 	log.Debug("epinioLocalLogin")
 
@@ -205,7 +205,7 @@ func (a *epinioAuth) verifyLocalLoginCreds(username, password string) error {
 }
 
 // ------------------
-//epinioOIDCLogin verifies DEX credentials
+// epinioOIDCLogin verifies DEX credentials
 func (a *epinioAuth) epinioOIDCLogin(c echo.Context) (string, string, error) {
 	log.Debug("epinioOIDCLogin")
 
@@ -231,15 +231,15 @@ func (a *epinioAuth) epinioOIDCLogin(c echo.Context) (string, string, error) {
 	oidcProvider, err := a.p.GetDex()
 
 	if err != nil {
-		msg := "unable to create dex client: %+v"
-		log.Errorf(msg, err)
+		msg := fmt.Sprintf("unable to create dex client: %+v", err)
+		log.Error(msg)
 		return "", "", errors.New(msg)
 	}
 
 	token, err := oidcProvider.ExchangeWithPKCE(c.Request().Context(), params.Code, params.CodeVerifier)
 	if err != nil {
-		msg := "failed to get token from code: %+v"
-		log.Errorf(msg, err)
+		msg := fmt.Sprintf("failed to get token from code: %+v", err)
+		log.Errorf(msg)
 		return "", "", errors.New(msg)
 	}
 
@@ -280,13 +280,12 @@ func (a *epinioAuth) epinioOIDCLogin(c echo.Context) (string, string, error) {
 }
 
 // ------------------
-//generateLoginSuccessResponse
+// generateLoginSuccessResponse
 func (e *epinioAuth) generateLoginSuccessResponse(c echo.Context, userGUID, username string) error {
 	log.Debug("generateLoginSuccessResponse")
 
 	var err error
-	var expiry int64
-	expiry = math.MaxInt64 // Basic auth type never expires
+	var expiry int64 = math.MaxInt64 // Basic auth type never expires
 
 	sessionValues := make(map[string]interface{})
 	sessionValues["user_id"] = userGUID
@@ -338,14 +337,17 @@ func (e *epinioAuth) generateLoginSuccessResponse(c echo.Context, userGUID, user
 	return err
 }
 
-//logout
+// logout
 func (a *epinioAuth) logout(c echo.Context) error {
 	a.p.removeEmptyCookie(c)
 
 	// Remove the XSRF Token from the session
-	a.p.unsetSessionValue(c, XSRFTokenSessionName)
+	err := a.p.unsetSessionValue(c, XSRFTokenSessionName)
+	if err != nil {
+		log.Errorf("Unable to unset session value: %v", err)
+	}
 
-	err := a.p.clearSession(c)
+	err = a.p.clearSession(c)
 	if err != nil {
 		log.Errorf("Unable to clear session: %v", err)
 	}

--- a/src/jetstream/cnsi_test.go
+++ b/src/jetstream/cnsi_test.go
@@ -33,8 +33,10 @@ func TestRegisterCFCluster(t *testing.T) {
 	_, _, ctx, pp, db, mock := setupHTTPTest(req)
 	defer db.Close()
 
+	metadata := `{"ui_url":"abc","dex_auth_url":"abc","dex_issuer":""}`
+
 	mock.ExpectExec(insertIntoCNSIs).
-		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "epinio", mockV2Info.URL, "abc", "", "abc", true, mockClientId, sqlmock.AnyArg(), false, "", "abc").
+		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "epinio", mockV2Info.URL, "abc", "", "abc", true, mockClientId, sqlmock.AnyArg(), false, "", metadata).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := pp.RegisterEndpoint(ctx, getCFPlugin(pp, "epinio").Info); err != nil {

--- a/src/jetstream/cnsi_test.go
+++ b/src/jetstream/cnsi_test.go
@@ -33,7 +33,7 @@ func TestRegisterCFCluster(t *testing.T) {
 	_, _, ctx, pp, db, mock := setupHTTPTest(req)
 	defer db.Close()
 
-	metadata := `{"ui_url":"abc","dex_auth_url":"abc","dex_issuer":""}`
+	metadata := `{"ui_url":"abc","dex_auth_url":"abc","dex_issuer":"abc"}`
 
 	mock.ExpectExec(insertIntoCNSIs).
 		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "epinio", mockV2Info.URL, "abc", "", "abc", true, mockClientId, sqlmock.AnyArg(), false, "", metadata).

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -1322,8 +1322,12 @@ func (p *portalProxy) GetDex() (interfaces.OIDCProvider, error) {
 		return nil, fmt.Errorf("failed to find epinio endpoint for dex auth url: %+v", err)
 	}
 
-	dexClient, err := dex.NewOIDCProviderWithEndpoint(p, context.Background(), epinioCnsi.AuthorizationEndpoint, epinioCnsi.Metadata)
+	metadata, err := epinio_utils.GetMetadata(epinioCnsi)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find epinio endpoint for dex auth url: %+v", err)
+	}
 
+	dexClient, err := dex.NewOIDCProviderWithEndpoint(p, context.Background(), epinioCnsi.AuthorizationEndpoint, metadata.DexIssuer, metadata.UIURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dex OIDC provider: %+v", err)
 	}

--- a/src/jetstream/plugins/epinio/interfaces/types.go
+++ b/src/jetstream/plugins/epinio/interfaces/types.go
@@ -3,3 +3,9 @@ package interfaces
 const (
 	EndpointType = "epinio"
 )
+
+type CNSIMetadata struct {
+	UIURL      string `json:"ui_url"`
+	DexAuthUrl string `json:"dex_auth_url"`
+	DexIssuer  string `json:"dex_issuer"`
+}

--- a/src/jetstream/plugins/epinio/main.go
+++ b/src/jetstream/plugins/epinio/main.go
@@ -66,15 +66,18 @@ func Init(portalProxy interfaces.PortalProxy) (interfaces.StratosPlugin, error) 
 	}
 
 	epinioAuthUrlValue, _ := portalProxy.Env().Lookup(epinioDexAuthUrl)
-	if len(epinioAuthUrlValue) == 0 {
+	if epinioAuthUrlValue == "" {
 		epinioAuthUrlValue = strings.Replace(epinioApiUrlValue, "epinio.", "auth.", 1)
 		log.Infof("Didn't find `%s`, falling back to `%s`", epinioDexAuthUrl, epinioAuthUrlValue)
 	}
 
 	epinioDexIssuerValue, _ := portalProxy.Env().Lookup(epinioDexIssuer)
+	if epinioDexIssuerValue == "" {
+		epinioDexIssuerValue = epinioAuthUrlValue
+	}
 
 	epinioUiUrlValue, _ := portalProxy.Env().Lookup(epinioUiUrl)
-	if len(epinioUiUrlValue) == 0 {
+	if epinioUiUrlValue == "" {
 		epinioUiUrlValue = epinioApiUrlValue // Default to the same as the epinio api
 	}
 

--- a/src/jetstream/plugins/epinio/utils/epinio-utils.go
+++ b/src/jetstream/plugins/epinio/utils/epinio-utils.go
@@ -1,6 +1,7 @@
 package epinio_utils
 
 import (
+	"encoding/json"
 	"fmt"
 
 	eInterfaces "github.com/epinio/ui-backend/src/jetstream/plugins/epinio/interfaces"
@@ -17,19 +18,24 @@ func FindEpinioEndpoint(p jInterfaces.PortalProxy) (*jInterfaces.CNSIRecord, err
 		return nil, fmt.Errorf(msg, err)
 	}
 
-	var epinioEndpoint *jInterfaces.CNSIRecord
 	for _, e := range endpoints {
 		if e.CNSIType == eInterfaces.EndpointType {
-			epinioEndpoint = e
-			break
+			return e, nil
 		}
 	}
 
-	if epinioEndpoint == nil {
-		msg := "failed to find an epinio endpoint"
-		log.Error(msg)
-		return nil, fmt.Errorf(msg)
+	msg := "failed to find an epinio endpoint"
+	log.Error(msg)
+	return nil, fmt.Errorf(msg)
+}
+
+func GetMetadata(record *jInterfaces.CNSIRecord) (eInterfaces.CNSIMetadata, error) {
+	var metadata eInterfaces.CNSIMetadata
+
+	err := json.Unmarshal([]byte(record.Metadata), &metadata)
+	if err != nil {
+		log.Errorf("error unmarshalling metadata [%s]: %s", record.Metadata, err.Error())
 	}
 
-	return epinioEndpoint, nil
+	return metadata, nil
 }


### PR DESCRIPTION
Fix: https://github.com/epinio/epinio/issues/2102
Fix: https://github.com/epinio/epinio/issues/2104

This PR adds the `EPINIO_DEX_ISSUER` to distinguish it from the `EPINIO_DEX_AUTH_URL`, that will be the internal Kubernetes service for Dex. This is needed to reach Dex when some local clusters are using the `127.0.0.1` ip (Rancher Desktop and Docker Desktop.

The construction of the redirect URL was also affected by this PR and it should fix the https://github.com/epinio/epinio/issues/2104

Relevant: https://github.com/epinio/helm-charts/pull/383
