### PR TITLE
Added `federated:id` claim in token request

### DIFF
--- a/src/jetstream/authepinio.go
+++ b/src/jetstream/authepinio.go
@@ -259,14 +259,16 @@ func (a *epinioAuth) epinioOIDCLogin(c echo.Context) (string, string, error) {
 	}
 
 	var claims struct {
-		Email   string      `json:"email"`
-		Groups  []string    `json:"groups"`
-		Profile interface{} `json:"profile"`
+		Email           string   `json:"email"`
+		Groups          []string `json:"groups"`
+		FederatedClaims struct {
+			ConnectorID string `json:"connector_id"`
+		} `json:"federated_claims"`
 	}
 	log.Warnf("epinioOIDCLogin: token: %+v", idToken)
 
 	if err := idToken.Claims(&claims); err != nil {
-		msg := "token in unexpected format: %+v"
+		msg := "token in unexpected format"
 		log.Errorf(msg, err)
 		return "", "", errors.New(msg)
 	}

--- a/src/jetstream/dex/dex.go
+++ b/src/jetstream/dex/dex.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	DefaultScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", "email", "groups", "audience:server:client_id:epinio-api"}
+	DefaultScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", "email", "groups", "audience:server:client_id:epinio-api", "federated:id"}
 )
 
 // OIDCProvider wraps an oidc.Provider and its Configuration


### PR DESCRIPTION
Fixes https://github.com/epinio/ui/issues/246

This PR adds the `federated:id` scope to the token request (https://dexidp.io/docs/custom-scopes-claims-clients/#scopes)

|Scope|Description|
|-|-|
|`federated:id`|ID token claims should include information from the ID provider. The token will contain the connector ID and the user ID assigned at the provider.|

This scope is used from the Epinio server to understand which was the provider used to login and use this information to associate the right group with the proper role.

See https://github.com/epinio/epinio/pull/1865/files for the server implementation.

