### PR TITLE
Copy response headers through proxied requests

### DIFF
--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -525,6 +525,7 @@ func (p *portalProxy) doRequest(cnsiRequest *interfaces.CNSIRequest, done chan<-
 	} else if res.Body != nil {
 		cnsiRequest.StatusCode = res.StatusCode
 		cnsiRequest.Status = res.Status
+		cnsiRequest.ResponseHeader = res.Header
 		cnsiRequest.Response, cnsiRequest.Error = ioutil.ReadAll(res.Body)
 		defer res.Body.Close()
 	}
@@ -592,6 +593,10 @@ func (p *portalProxy) ProxySingleRequest(c echo.Context) error {
 
 	go p.doRequest(&cnsiRequest, done)
 	res := <-done
+
+	// Copy custom content-length header from original response header
+	contentLength := "x-content-length"
+	c.Response().Header().Set(contentLength, res.ResponseHeader.Get(contentLength))
 
 	// FIXME: cnsiRequest.Status info is lost for failures, only get a status code
 	c.Response().WriteHeader(res.StatusCode)

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -39,7 +39,7 @@ type V2Info struct {
 
 type InfoFunc func(apiEndpoint string, skipSSLValidation bool) (CNSIRecord, interface{}, error)
 
-//TODO this could be moved back to cnsis subpackage, and extensions could import it?
+// TODO this could be moved back to cnsis subpackage, and extensions could import it?
 type CNSIRecord struct {
 	GUID                   string   `json:"guid"`
 	Name                   string   `json:"name"`
@@ -260,7 +260,7 @@ type Versions struct {
 	DatabaseVersion int64  `json:"database_version"`
 }
 
-//AuthEndpointType - Restrict the possible values of the configured
+// AuthEndpointType - Restrict the possible values of the configured
 type AuthEndpointType string
 
 const (
@@ -274,8 +274,8 @@ const (
 	AuthNone AuthEndpointType = "none"
 )
 
-//AuthEndpointTypes - Allows lookup of internal string representation by the
-//value of the AUTH_ENDPOINT_TYPE env variable
+// AuthEndpointTypes - Allows lookup of internal string representation by the
+// value of the AUTH_ENDPOINT_TYPE env variable
 var AuthEndpointTypes = map[string]AuthEndpointType{
 	"remote": Remote,
 	"local":  Local,
@@ -352,20 +352,21 @@ func (consoleConfig *ConsoleConfig) IsSetupComplete() bool {
 
 // CNSIRequest
 type CNSIRequest struct {
-	GUID         string       `json:"-"`
-	UserGUID     string       `json:"-"`
-	Method       string       `json:"-"`
-	Body         []byte       `json:"-"`
-	Header       http.Header  `json:"-"`
-	URL          *url.URL     `json:"-"`
-	StatusCode   int          `json:"statusCode"`
-	Status       string       `json:"status"`
-	PassThrough  bool         `json:"-"`
-	LongRunning  bool         `json:"-"`
-	Response     []byte       `json:"-"`
-	Error        error        `json:"-"`
-	ResponseGUID string       `json:"-"`
-	Token        *TokenRecord `json:"-"` // Optional Token record to use instead of looking up
+	GUID           string       `json:"-"`
+	UserGUID       string       `json:"-"`
+	Method         string       `json:"-"`
+	Body           []byte       `json:"-"`
+	Header         http.Header  `json:"-"`
+	URL            *url.URL     `json:"-"`
+	StatusCode     int          `json:"statusCode"`
+	Status         string       `json:"status"`
+	PassThrough    bool         `json:"-"`
+	LongRunning    bool         `json:"-"`
+	ResponseHeader http.Header  `json:"-"`
+	Response       []byte       `json:"-"`
+	Error          error        `json:"-"`
+	ResponseGUID   string       `json:"-"`
+	Token          *TokenRecord `json:"-"` // Optional Token record to use instead of looking up
 }
 
 type PortalConfig struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The response headers are truncate for proxied https requests to Epinio server.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One of the missing response headers is `X-Content_Length`, which should be used to calculate download progress on the UI.
Related issue: https://github.com/epinio/ui/issues/223
