### PR TITLE
Update release job to match release-next and build ui from epinio/ui

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      ui_bundle_url:
+        description: "ui_bundle_url"
+        required: false
+        type: string
 
 env:
   SETUP_GO_VERSION: '1.18'
-  # change this to embed a different UI dashboard
-  UI_BUNDLE_URL: https://github.com/rancher/dashboard/releases/download/epinio-standalone-v1.8.1-0.0.1/rancher-dashboard-epinio-standalone-embed.tar.gz
 
 jobs:
   release:
@@ -45,21 +49,53 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Download dashboard
-        run: |
-          mkdir ui
-          wget "${{ env.UI_BUNDLE_URL }}"
-          tar xfz *.tar.gz -C ui
-      -
         name: Get current tag
         id: get_tag
         run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+      # if the ui_bundle_url is defined download and unpack the dashboard
+      -
+        name: Download dashboard
+        if: ${{ github.event.inputs.ui_bundle_url != '' }}
+        run: |
+          mkdir ui
+          wget "${{ github.event.inputs.ui_bundle_url }}"
+          tar xfz *.tar.gz -C ui
+      # otherwise fetch and build the latest dashboard from the repository
+      -
+        name: Checkout Rancher Dashboard UI
+        if: ${{ github.event.inputs.ui_bundle_url == '' }}
+        uses: actions/checkout@v3
+        with:
+          repository: epinio/ui
+          ref: main
+          submodules: recursive
+          fetch-depth: 0
+          path: epinio-ui
+      -
+        name: Build Epinio dashboard
+        if: ${{ github.event.inputs.ui_bundle_url == '' }}
+        # go to the repo's directory, build the ui, move the build to `ui` in the workflow root (as per location when downloading from url)
+        run: |
+          pushd epinio-ui
+          ./.github/workflows/scripts/build-ui.sh
+          mv dashboard/$OUTPUT_DIR/$ARTIFACT_NAME ../ui
+          popd
+          rm -rf epinio-ui
+        env:
+          RANCHER_ENV: epinio
+          EXCLUDES_PKG: rancher-components,harvester
+          EXCLUDE_OPERATOR_PKG: true
+          OUTPUT_DIR: dist
+          RELEASE_DIR: release
+          ARTIFACT_NAME: rancher-dashboard-epinio-standalone
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          LOGIN_LOCALE_SELECTOR: false
       -
         name: Run GoReleaser Cross
         run: ./build/bk-release.sh release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UI_BUNDLE_URL: "${{ env.UI_BUNDLE_URL }}"
+          UI_BUNDLE_URL: "${{ github.event.inputs.ui_bundle_url }}"
           # The "id-token: write" permission for the OIDC will set the ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN
           # environment variables. Since we are running goreleaser-cross from a Docker image we need to pass those to the script and the container.
           # See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#updating-your-actions-for-oidc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: epinio/ui
-          ref: main
+          ref: ${{ steps.get_tag.outputs.TAG }}
           submodules: recursive
           fetch-depth: 0
           path: epinio-ui


### PR DESCRIPTION
- as per changes to https://github.com/epinio/ui-backend/blob/main/.github/workflows/release-next.yml
- [PR](https://github.com/epinio/ui/pull/266) epinio/ui side with updated release docs